### PR TITLE
Response objects rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ For IntegrationTests on a build server environment variables can be used instead
 ##### Scores
 
 ```csharp
-        var request = new ScoresSearchRequest()
+        var request = new ScoresRequest()
         {
             Bin = "700000001",
             Subcode         = "0517614",
@@ -288,7 +288,7 @@ For IntegrationTests on a build server environment variables can be used instead
             CommercialScore = true,
         };
 
-        var response = serviceClient.PostScoresSearchAsync(Environment.Sandbox, authResponse, request);
+        var response = serviceClient.PostScoresAsync(Environment.Sandbox, authResponse, request);
 ```
 
 ##### Trades

--- a/src/Client/Bis/ApiExtensions.cs
+++ b/src/Client/Bis/ApiExtensions.cs
@@ -77,52 +77,52 @@
             }
         }
 
-        public static async Task<ReverseAddressesReponse>       PostReverseAddressAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReverseAddressesRequest request)
+        public static async Task<ReverseAddressesResponse>       PostReverseAddressAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReverseAddressesRequest request)
         {
             var url = ServiceUri[(env, ReverseAddresses)];
-            return await serviceClient.SendRequestAsync<ReverseAddressesRequest, ReverseAddressesReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<ReverseAddressesRequest, ReverseAddressesResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<BankruptcyReponse>             PostBankruptcyAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BankruptcyRequest request)
+        public static async Task<BankruptcyResponse>             PostBankruptcyAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BankruptcyRequest request)
         {
             var url = ServiceUri[(env, Bankruptcies)];
-            return await serviceClient.SendRequestAsync<BankruptcyRequest, BankruptcyReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<BankruptcyRequest, BankruptcyResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<BusinessContactsReponse>       PostBusinessContactsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BusinessContactsRequest request)
+        public static async Task<BusinessContactsResponse>       PostBusinessContactsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BusinessContactsRequest request)
         {
             var url = ServiceUri[(env, BusinessContacts)];
-            return await serviceClient.SendRequestAsync<BusinessContactsRequest, BusinessContactsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<BusinessContactsRequest, BusinessContactsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<BusinessFactsReponse>          PostBusinessFactsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BusinessFactsRequest request)
+        public static async Task<BusinessFactsResponse>          PostBusinessFactsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BusinessFactsRequest request)
         {
             var url = ServiceUri[(env, Facts)];
-            return await serviceClient.SendRequestAsync<BusinessFactsRequest, BusinessFactsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<BusinessFactsRequest, BusinessFactsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<CorporateRegistrationsReponse> PostCorporateRegistrationsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CorporateRegistrationsRequest request)
+        public static async Task<CorporateRegistrationsResponse> PostCorporateRegistrationsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CorporateRegistrationsRequest request)
         {
             var url = ServiceUri[(env, CorporateRegistrations)];
-            return await serviceClient.SendRequestAsync<CorporateRegistrationsRequest, CorporateRegistrationsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<CorporateRegistrationsRequest, CorporateRegistrationsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<CollectionsReponse>            PostCollectionsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
+        public static async Task<CollectionsResponse>            PostCollectionsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
         {
             var url = ServiceUri[(env, Collections)];
-            return await serviceClient.SendRequestAsync<BisRequest, CollectionsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<BisRequest, CollectionsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<CorporateLinkageReponse>       PostCorporateLinkageAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CorporateLinkageRequest request)
+        public static async Task<CorporateLinkageResponse>       PostCorporateLinkageAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CorporateLinkageRequest request)
         {
             var url = ServiceUri[(env, CorporateLinkage)];
-            return await serviceClient.SendRequestAsync<CorporateLinkageRequest, CorporateLinkageReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<CorporateLinkageRequest, CorporateLinkageResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<CreditStatusReponse>           PostCreditStatusAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CreditStatusRequest request)
+        public static async Task<CreditStatusResponse>           PostCreditStatusAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CreditStatusRequest request)
         {
             var url = ServiceUri[(env, CreditStatus)];
-            return await serviceClient.SendRequestAsync<CreditStatusRequest, CreditStatusReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<CreditStatusRequest, CreditStatusResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
         public static async Task<BisResponse>               PostFactsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
@@ -131,88 +131,88 @@
             return await serviceClient.SendRequestAsync<BisRequest, BisResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<FraudShieldsReponse>           PostFraudShieldsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, FraudShieldsRequest request)
+        public static async Task<FraudShieldsResponse>           PostFraudShieldsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, FraudShieldsRequest request)
         {
             var url = ServiceUri[(env, FraudShields)];
-            return await serviceClient.SendRequestAsync<FraudShieldsRequest, FraudShieldsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<FraudShieldsRequest, FraudShieldsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<HeadersReponse>                PostHeadersAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, HeadersRequest request)
+        public static async Task<HeadersResponse>                PostHeadersAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, HeadersRequest request)
         {
             var url = ServiceUri[(env, Headers)];
-            return await serviceClient.SendRequestAsync<HeadersRequest, HeadersReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<HeadersRequest, HeadersResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<JudgmentsReponse>              PostJudgmentsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, JudgmentsRequest request)
+        public static async Task<JudgmentsResponse>              PostJudgmentsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, JudgmentsRequest request)
         {
             var url = ServiceUri[(env, Judgments)];
-            return await serviceClient.SendRequestAsync<JudgmentsRequest, JudgmentsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<JudgmentsRequest, JudgmentsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<LegalCollectionsSummariesReponse> PostLegalCollectionSummariesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, LegalFilingsCollectionsSummariesRequest request)
+        public static async Task<LegalCollectionsSummariesResponse> PostLegalCollectionSummariesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, LegalFilingsCollectionsSummariesRequest request)
         {
             var url = ServiceUri[(env, LegalCollectionSummaries)];
-            return await serviceClient.SendRequestAsync<LegalFilingsCollectionsSummariesRequest, LegalCollectionsSummariesReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<LegalFilingsCollectionsSummariesRequest, LegalCollectionsSummariesResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<LiensReponse>                  PostLiensAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, LiensRequest request)
+        public static async Task<LiensResponse>                  PostLiensAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, LiensRequest request)
         {
             var url = ServiceUri[(env, Liens)];
-            return await serviceClient.SendRequestAsync<LiensRequest, LiensReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<LiensRequest, LiensResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<ReverseAddressesReponse>       PostReverseAddressesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReverseAddressesRequest request)
+        public static async Task<ReverseAddressesResponse>       PostReverseAddressesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReverseAddressesRequest request)
         {
             var url = ServiceUri[(env, ReverseAddresses)];
-            return await serviceClient.SendRequestAsync<ReverseAddressesRequest, ReverseAddressesReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<ReverseAddressesRequest, ReverseAddressesResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<ReversePhonesReponse>          PostReversePhonesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReversePhonesRequest request)
+        public static async Task<ReversePhonesResponse>          PostReversePhonesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReversePhonesRequest request)
         {
             var url = ServiceUri[(env, ReversePhones)];
-            return await serviceClient.SendRequestAsync<ReversePhonesRequest, ReversePhonesReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<ReversePhonesRequest, ReversePhonesResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<ReverseTaxIdsReponse>          PostReverseTaxidsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReverseTaxIdsRequest request)
+        public static async Task<ReverseTaxIdsResponse>          PostReverseTaxidsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ReverseTaxIdsRequest request)
         {
             var url = ServiceUri[(env, ReverseTaxIds)];
-            return await serviceClient.SendRequestAsync<ReverseTaxIdsRequest, ReverseTaxIdsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<ReverseTaxIdsRequest, ReverseTaxIdsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<RiskDashboardsReponse>         PostRiskDashboardsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, RiskDashboardsRequest request)
+        public static async Task<RiskDashboardsResponse>         PostRiskDashboardsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, RiskDashboardsRequest request)
         {
             var url = ServiceUri[(env, RiskDashboards)];
-            return await serviceClient.SendRequestAsync<RiskDashboardsRequest, RiskDashboardsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<RiskDashboardsRequest, RiskDashboardsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<ScoresReponse>                 PostScoresAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ScoresRequest request)
+        public static async Task<ScoresResponse>                 PostScoresAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ScoresRequest request)
         {
             var url = ServiceUri[(env, Scores)];
-            return await serviceClient.SendRequestAsync<ScoresRequest, ScoresReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<ScoresRequest, ScoresResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<SearchReponse>                 PostSearchAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, SearchRequest request)
+        public static async Task<SearchResponse>                 PostSearchAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, SearchRequest request)
         {
             var url = ServiceUri[(env, Search)];
-            return await serviceClient.SendRequestAsync<SearchRequest, SearchReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<SearchRequest, SearchResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<TradesReponse>                 PostTradesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, TradesRequest request)
+        public static async Task<TradesResponse>                 PostTradesAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, TradesRequest request)
         {
             var url = ServiceUri[(env, Trades)];
-            return await serviceClient.SendRequestAsync<TradesRequest, TradesReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<TradesRequest, TradesResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<UccFilingsReponse>             PostUccFilingsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, UccFilingsRequest request)
+        public static async Task<UccFilingsResponse>             PostUccFilingsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, UccFilingsRequest request)
         {
             var url = ServiceUri[(env, UccFilings)];
-            return await serviceClient.SendRequestAsync<UccFilingsRequest, UccFilingsReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<UccFilingsRequest, UccFilingsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<ScoresSearchReponse>           PostScoresSearchAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
+        public static async Task<ScoresSearchResponse>           PostScoresSearchAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
         {
             var url = ServiceUri[(env, ScoresSearch)];
-            return await serviceClient.SendRequestAsync<BisRequest, ScoresSearchReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<BisRequest, ScoresSearchResponse>(url, authToken, request).ConfigureAwait(false);
         }
     }
 }

--- a/src/Client/Bis/ApiExtensions.cs
+++ b/src/Client/Bis/ApiExtensions.cs
@@ -185,10 +185,10 @@
             return await serviceClient.SendRequestAsync<RiskDashboardsRequest, RiskDashboardsReponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<ScoresReponse>                 PostScoresAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
+        public static async Task<ScoresReponse>                 PostScoresAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, ScoresRequest request)
         {
             var url = ServiceUri[(env, Scores)];
-            return await serviceClient.SendRequestAsync<BisRequest, ScoresReponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<ScoresRequest, ScoresReponse>(url, authToken, request).ConfigureAwait(false);
         }
 
         public static async Task<SearchReponse>                 PostSearchAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, SearchRequest request)

--- a/src/Client/Bis/BankruptcyResponse.cs
+++ b/src/Client/Bis/BankruptcyResponse.cs
@@ -2,7 +2,7 @@ namespace Experian.Api.Client.Bis
 {
     using System;
 
-    public sealed class BankruptcyReponse : BisResponse
+    public sealed class BankruptcyResponse : BisResponse
     {
         public BankruptcyResult Results { get; set; }
     }

--- a/src/Client/Bis/BusinessContactsResponse.cs
+++ b/src/Client/Bis/BusinessContactsResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class BusinessContactsReponse : BisResponse
+    public sealed class BusinessContactsResponse : BisResponse
     {
         public BusinessContactsResult Results { get; set; }
     }

--- a/src/Client/Bis/BusinessFactsResponse.cs
+++ b/src/Client/Bis/BusinessFactsResponse.cs
@@ -1,6 +1,6 @@
     namespace Experian.Api.Client.Bis
     {
-        public class BusinessFactsReponse : BisResponse
+        public class BusinessFactsResponse : BisResponse
         {
             public BusinessFactsResult Results { get; set; }
         }

--- a/src/Client/Bis/CollectionsResponse.cs
+++ b/src/Client/Bis/CollectionsResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class CollectionsReponse : BisResponse
+    public sealed class CollectionsResponse : BisResponse
     {
         public CollectionsResult Results { get; set; }
     }

--- a/src/Client/Bis/CorporateLinkageResponse.cs
+++ b/src/Client/Bis/CorporateLinkageResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class CorporateLinkageReponse : BisResponse
+    public sealed class CorporateLinkageResponse : BisResponse
     {
         public CorporateLinkageResult Results { get; set; }
     }

--- a/src/Client/Bis/CorporateRegistrationsResponse.cs
+++ b/src/Client/Bis/CorporateRegistrationsResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class CorporateRegistrationsReponse : BisResponse
+    public sealed class CorporateRegistrationsResponse : BisResponse
     {
         public CorporateRegistrationsResult Results { get; set; }
     }

--- a/src/Client/Bis/CreditStatusResponse.cs
+++ b/src/Client/Bis/CreditStatusResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class CreditStatusReponse : BisResponse
+    public sealed class CreditStatusResponse : BisResponse
     {
         public CreditStatusResult Results { get; set; }
     }

--- a/src/Client/Bis/FraudShieldsResponse.cs
+++ b/src/Client/Bis/FraudShieldsResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-public sealed class FraudShieldsReponse : BisResponse
+public sealed class FraudShieldsResponse : BisResponse
 {
     public FraudShieldsResult Results { get; set; }
 }

--- a/src/Client/Bis/HeadersResponse.cs
+++ b/src/Client/Bis/HeadersResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-public sealed class HeadersReponse : BisResponse
+public sealed class HeadersResponse : BisResponse
 {
     public BusinessHeaderResult Results { get; set; }
 }

--- a/src/Client/Bis/JudgmentsResponse.cs
+++ b/src/Client/Bis/JudgmentsResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class JudgmentsReponse : BisResponse
+    public sealed class JudgmentsResponse : BisResponse
     {
         public JudgmentsResult Results { get; set; }
     }

--- a/src/Client/Bis/LegalCollectionsSummariesResponse.cs
+++ b/src/Client/Bis/LegalCollectionsSummariesResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class LegalCollectionsSummariesReponse : BisResponse
+    public sealed class LegalCollectionsSummariesResponse : BisResponse
     {
         public LegalCollectionsSummariesResult Results { get; set; }
     }

--- a/src/Client/Bis/LiensResponse.cs
+++ b/src/Client/Bis/LiensResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class LiensReponse : BisResponse
+    public sealed class LiensResponse : BisResponse
     {
         public LiensResult Results { get; set; }
     }

--- a/src/Client/Bis/ReverseAddressesResponse.cs
+++ b/src/Client/Bis/ReverseAddressesResponse.cs
@@ -3,7 +3,7 @@ namespace Experian.Api.Client.Bis
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public sealed class ReverseAddressesReponse : BisResponse
+    public sealed class ReverseAddressesResponse : BisResponse
     {
         [JsonProperty(PropertyName = "reverseAddresses")]
         public List<ReverseAddressesItemsResult> Results { get; set; }

--- a/src/Client/Bis/ReversePhonesResponse.cs
+++ b/src/Client/Bis/ReversePhonesResponse.cs
@@ -3,7 +3,7 @@ namespace Experian.Api.Client.Bis
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public sealed class ReversePhonesReponse : BisResponse
+    public sealed class ReversePhonesResponse : BisResponse
     {
         [JsonProperty(PropertyName = "reversePhones")]
         public List<ReversePhonesItemsResult> Results { get; set; }

--- a/src/Client/Bis/ReverseTaxIdsResponse.cs
+++ b/src/Client/Bis/ReverseTaxIdsResponse.cs
@@ -4,7 +4,7 @@ namespace Experian.Api.Client.Bis
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-public sealed class ReverseTaxIdsReponse : BisResponse
+public sealed class ReverseTaxIdsResponse : BisResponse
 {
         [JsonProperty(PropertyName = "reverseTaxIds")]
         public List<ReverseTaxIdsItemsResult> Results { get; set; }

--- a/src/Client/Bis/RiskDashboardsResponse.cs
+++ b/src/Client/Bis/RiskDashboardsResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class RiskDashboardsReponse : BisResponse
+    public sealed class RiskDashboardsResponse : BisResponse
     {
         public RiskDashboardsResult Results { get; set; }
     }

--- a/src/Client/Bis/ScoresRequest.cs
+++ b/src/Client/Bis/ScoresRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace Experian.Api.Client.Bis
+{
+    public sealed class ScoresRequest : BisRequest
+    {
+        public string ModelCode { get; set; }
+
+        public bool FsrScore { get; set; }
+
+        public bool CommercialScore { get; set; }
+    }
+}

--- a/src/Client/Bis/ScoresResponse.cs
+++ b/src/Client/Bis/ScoresResponse.cs
@@ -2,7 +2,7 @@ namespace Experian.Api.Client.Bis
 {
     using System.Collections.Generic;
 
-    public sealed class ScoresReponse : BisResponse
+    public sealed class ScoresResponse : BisResponse
     {
         public List<ScoresResult> Results { get; set; }
     }

--- a/src/Client/Bis/ScoresSearchResponse.cs
+++ b/src/Client/Bis/ScoresSearchResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public class ScoresSearchReponse : BisResponse
+    public class ScoresSearchResponse : BisResponse
     {
         public ScoresSearchResult Results { get; set; }
     }

--- a/src/Client/Bis/SearchResponse.cs
+++ b/src/Client/Bis/SearchResponse.cs
@@ -2,7 +2,7 @@ namespace Experian.Api.Client.Bis
 {
     using System.Collections.Generic;
 
-    public sealed class SearchReponse : BisResponse
+    public sealed class SearchResponse : BisResponse
     {
         public List<SearchResult> Results { get; set; }
     }

--- a/src/Client/Bis/TradesResponse.cs
+++ b/src/Client/Bis/TradesResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-public sealed class TradesReponse : BisResponse
+public sealed class TradesResponse : BisResponse
 {
     public TradesResult Results { get; set; }
 }

--- a/src/Client/Bis/UccFilingsResponse.cs
+++ b/src/Client/Bis/UccFilingsResponse.cs
@@ -1,6 +1,6 @@
 namespace Experian.Api.Client.Bis
 {
-    public sealed class UccFilingsReponse : BisResponse
+    public sealed class UccFilingsResponse : BisResponse
     {
         public UccFilingsSummaryResult Results { get; set; }
     }


### PR DESCRIPTION
Fixes typos in the name of some response objects.  The file names were correct but the class names themselves were spelled "*reponse" instead of "*response".  Note that this pull request is dependent on the Scores request one being completed.

**Important Note: This will be a breaking change for any existing users of this SDK as it renames response objects.** 