### PR TITLE
Scores response deserialization fixes

### DIFF
--- a/src/Client/Bis/CommercialScoreResult.cs
+++ b/src/Client/Bis/CommercialScoreResult.cs
@@ -12,7 +12,7 @@ namespace Experian.Api.Client.Bis
 
         public int PercentileRanking { get; set; }
 
-        public int RecommendedCreditLimitAmount { get; set; }
+        public int? RecommendedCreditLimitAmount { get; set; }
 
         public RiskClassResult RiskClass { get; set; }
     }

--- a/src/Client/Bis/ScoresResponse.cs
+++ b/src/Client/Bis/ScoresResponse.cs
@@ -1,9 +1,7 @@
 namespace Experian.Api.Client.Bis
 {
-    using System.Collections.Generic;
-
     public sealed class ScoresResponse : BisResponse
     {
-        public List<ScoresResult> Results { get; set; }
+        public ScoresResult Results { get; set; }
     }
 }


### PR DESCRIPTION
- Changed CommercialScoreResult.RecommendedCreditLimitAmount from int to nullable int.
- Changed ScoresResponse.Results from collection to single object.

