### PR TITLE
Changed Code property from int to string to match what the API can return

### DIFF
--- a/src/Client/Bis/CollateralCodesResult.cs
+++ b/src/Client/Bis/CollateralCodesResult.cs
@@ -2,7 +2,7 @@ namespace Experian.Api.Client.Bis
 {
     public sealed class CollateralCodesResult
     {
-        public int Code { get; set; }
+        public string Code { get; set; }
 
         public string Definition { get; set; }
     }


### PR DESCRIPTION
Looks like this API can return a string for the code here instead of just ints.  I got a "H" back earlier which blew up during deserialization.