### PR TITLE
Collections api request object

### DIFF
--- a/src/Client/Bis/ApiExtensions.cs
+++ b/src/Client/Bis/ApiExtensions.cs
@@ -107,10 +107,10 @@
             return await serviceClient.SendRequestAsync<CorporateRegistrationsRequest, CorporateRegistrationsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<CollectionsResponse>            PostCollectionsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CollectionsRequest request)
+        public static async Task<CollectionsResponse>            PostCollectionsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
         {
             var url = ServiceUri[(env, Collections)];
-            return await serviceClient.SendRequestAsync<CollectionsRequest, CollectionsResponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<BisRequest, CollectionsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
         public static async Task<CorporateLinkageResponse>       PostCorporateLinkageAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CorporateLinkageRequest request)

--- a/src/Client/Bis/ApiExtensions.cs
+++ b/src/Client/Bis/ApiExtensions.cs
@@ -107,10 +107,10 @@
             return await serviceClient.SendRequestAsync<CorporateRegistrationsRequest, CorporateRegistrationsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
-        public static async Task<CollectionsResponse>            PostCollectionsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, BisRequest request)
+        public static async Task<CollectionsResponse>            PostCollectionsAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CollectionsRequest request)
         {
             var url = ServiceUri[(env, Collections)];
-            return await serviceClient.SendRequestAsync<BisRequest, CollectionsResponse>(url, authToken, request).ConfigureAwait(false);
+            return await serviceClient.SendRequestAsync<CollectionsRequest, CollectionsResponse>(url, authToken, request).ConfigureAwait(false);
         }
 
         public static async Task<CorporateLinkageResponse>       PostCorporateLinkageAsync(this ServiceClient serviceClient, Environ env, AuthResult authToken, CorporateLinkageRequest request)

--- a/src/Client/Bis/CollectionsRequest.cs
+++ b/src/Client/Bis/CollectionsRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace Experian.Api.Client.Bis
+{
+    public class CollectionsRequest : BisRequest
+    {
+        public bool CollectionsSummary { get; set; }
+
+        public bool CollectionsDetail { get; set; }
+    }
+}


### PR DESCRIPTION
I noticed the Collections API was using BisRequest instead of a custom request object.  I made one so that callers could specify their own values for CollectionsSummary and CollectionsDetail.